### PR TITLE
Fix zinc dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,10 +7,10 @@ repositories {
     mavenCentral()
 }
 
-configurations.all {
+configurations.zinc {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
       if (details.requested.group == 'org.scala-lang') {
-        details.useVersion '2.12.15'
+        details.useVersion '2.13.11'
       }
     }
 }


### PR DESCRIPTION
Please refer to [Zinc compatibility table](https://docs.gradle.org/current/userguide/scala_plugin.html#sec:configure_zinc_compiler)
Since Gradle 7.5 is used, it requires Scala 2.13.x to run Zinc. To be able to compile Scala 2.12.x sources, you need to configure Zinc plugin resolution strategy so it may use Scala 2.13.x.